### PR TITLE
test_tc_017_04_06_new_api_key_default_status_is_active added

### DIFF
--- a/locators/API_keys_locators.py
+++ b/locators/API_keys_locators.py
@@ -19,4 +19,6 @@ class ApiKeysLocator:
     NOTICE_MESSAGE = By.XPATH, "//div[@class='panel-body']"
 
 
-
+    def row_elements(self, row_number):
+        t_r = By.XPATH, f"//tbody/tr[{row_number}]/td"
+        return t_r

--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -73,9 +73,18 @@ class ApiKeysPage(BasePage):
         actual_api_keys_table_length = self.get_length_of_table_api_keys()
         assert actual_api_keys_table_length == initial_table_length + 1, "The new API key does not generated"
 
-
     def check_is_success_generate_notice_displayed(self):
         expected_new_api_key_notice_text = 'API key was created successfully'
         actual_new_api_key_notice_text = self.driver.find_element(*ApiKeysLocator.NOTICE_MESSAGE).text
-        assert actual_new_api_key_notice_text == expected_new_api_key_notice_text,\
+        assert actual_new_api_key_notice_text == expected_new_api_key_notice_text, \
             "The success generate API key notice text does not displayed"
+
+    def get_last_row_elements_from_api_keys_able(self):
+        len_t = self.get_length_of_table_api_keys()
+        column_values = self.elements_are_visible(ApiKeysLocator.row_elements(self, 2))
+        return column_values
+
+    def check_default_status_generated_api_key(self):
+        last_row_elements = self.get_last_row_elements_from_api_keys_able()
+        new_generated_api_key_status = last_row_elements[2].text
+        assert new_generated_api_key_status == "Active", "The default status of the new API key does not  'Active'"

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -38,4 +38,12 @@ class TestApiKey:
         api_keys_page.click_generate_api_key_name_button()
         api_keys_page.check_is_success_generate_notice_displayed()
 
+    def test_tc_017_04_06_new_api_key_default_status_is_active(self, driver):
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.enter_created_api_key_name("Default status check name ")
+        api_keys_page.click_generate_api_key_name_button()
+        api_keys_page.check_default_status_generated_api_key()
+
+
 


### PR DESCRIPTION
TC_017.04.07 : https://trello.com/c/UY63LAxI/53-tc0170407-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-default-status-of-the-new-api-key-is-acti
AT_017.04.07 : https://trello.com/c/LNcOUMDK/3-at0170407-api-keys-tabcreating-api-key-visibility-clickability-creatingverify-that-the-default-status-of-the-new-api-key-is-acti