### PR TITLE
AT_017.02.01| API Keys tab > Change status of API Key > Visibility, clickability ,changing > Initial status of API key is display

### DIFF
--- a/locators/API_keys_locators.py
+++ b/locators/API_keys_locators.py
@@ -24,3 +24,7 @@ class ApiKeysLocator:
     def row_elements(self, row_number):
         t_r = By.XPATH, f"//tbody/tr[{row_number}]/td"
         return t_r
+
+    def status_api_key(self, row_num):
+        return By.XPATH, f"//div//tr[{row_num}]/td[3]/span"
+

--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -105,3 +105,9 @@ class ApiKeysPage(BasePage):
     def check_is_displayed_api_keys_list(self):
         api_keys_list = self.element_is_displayed(ApiKeysLocator.TABLE_API_KEYS)
         assert api_keys_list, "The API keys list does not displayed"
+
+    def check_is_api_keys_status_displayed(self):
+        length_api_keys_table = self.get_length_of_table_api_keys()
+        for i in range(1, length_api_keys_table + 1):
+            status_display = self.element_is_displayed(ApiKeysLocator.status_api_key(self, i))
+            assert status_display, f"The API key status does not display in the row {i}. "

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -25,6 +25,10 @@ class TestApiKey:
         api_keys_page.open_api_keys_page()
         api_keys_page.check_is_displayed_api_keys_list()
 
+    def test_tc_017_02_0_api_keys_status_are_displayed(self, driver):
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.check_is_api_keys_status_displayed()
 
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -25,7 +25,7 @@ class TestApiKey:
         api_keys_page.open_api_keys_page()
         api_keys_page.check_is_displayed_api_keys_list()
 
-    def test_tc_017_02_0_api_keys_status_are_displayed(self, driver):
+    def test_tc_017_02_01_api_keys_status_are_displayed(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()
         api_keys_page.check_is_api_keys_status_displayed()


### PR DESCRIPTION
AT_017.02.01 : https://trello.com/c/9P9V04zM/643-at0170201-api-keys-tab-change-status-of-api-key-visibility-clickability-changing-initial-status-of-api-key-is-display
TC_017.02.01: https://trello.com/c/V174c7ZA/36-tc0170201-api-keys-tab-change-status-of-api-key-visibility-clickability-changing-initial-status-of-api-key-is-display