### PR TITLE
test_tc_017_02_03_the_inactive_status_of_api_key_is_red added

### DIFF
--- a/locators/API_keys_locators.py
+++ b/locators/API_keys_locators.py
@@ -22,6 +22,7 @@ class ApiKeysLocator:
     TABLE_API_KEYS = By.CSS_SELECTOR, ".material_table.api-keys"
     SWITCH_STATUS_TO_ACTIVE = By.CSS_SELECTOR, '.fa.fa-toggle-off'
     SWITCH_STATUS_TO_INACTIVE = By.CSS_SELECTOR, '.fa.fa-toggle-on'
+    STATUS_COLOR = By.CSS_SELECTOR, "span:nth-child(1)"
 
 
 

--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from pages.base_page import BasePage
 from locators.API_keys_locators import ApiKeysLocator
 from pages.sign_in_page import SignInPage
@@ -138,3 +140,9 @@ class ApiKeysPage(BasePage):
     def check_is_status_api_key_changed(self, initial_status_api_key, row_num):
         current_status = self.get_api_key_initial_status(row_num)
         assert current_status != initial_status_api_key, "API Key status has not changed"
+
+    def check_is_status_api_key_red(self, row_num):
+        row_values = self.get_row_elements_by_number_from_api_keys_table(row_num)
+        color = row_values[2].find_element(*ApiKeysLocator.STATUS_COLOR).value_of_css_property("color")
+        assert "255, 0, 0," in color, "The inactive API key status does not red"
+

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -37,6 +37,15 @@ class TestApiKey:
         api_keys_page.click_switch_status_icon(row_num)
         api_keys_page.check_is_status_api_key_changed(initial_status, row_num)
 
+    def test_tc_017_02_03_the_inactive_status_of_api_key_is_red(self, driver):
+        row_num = 1
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        initial_status = api_keys_page.get_api_key_initial_status(row_num)
+        if initial_status == "Active":
+            api_keys_page.click_switch_status_icon(row_num)
+        api_keys_page.check_is_status_api_key_red(row_num)
+
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()


### PR DESCRIPTION
TC_017.02.03 : https://trello.com/c/UvVZs1xk/34-tc0170203-api-keys-tab-change-status-of-api-key-visibility-clickability-changing-the-color-of-inactive-status-is-red
AT_017.02.03 : https://trello.com/c/zSLC4NtJ/645-at0170203-api-keys-tab-change-status-of-api-key-visibility-clickability-changing-the-color-of-inactive-status-is-red