### PR TITLE
test_tc_017_02_08_the_active_status_of_api_key_is_black added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -146,3 +146,8 @@ class ApiKeysPage(BasePage):
         color = row_values[2].find_element(*ApiKeysLocator.STATUS_COLOR).value_of_css_property("color")
         assert "255, 0, 0," in color, "The inactive API key status does not red"
 
+    def check_is_status_api_key_black(self, row_num):
+        row_values = self.get_row_elements_by_number_from_api_keys_table(row_num)
+        color = row_values[2].find_element(*ApiKeysLocator.STATUS_COLOR).value_of_css_property("color")
+        assert "72, 72, 74" in color, "The inactive API key status does not black"
+

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -1,4 +1,3 @@
-
 from pages.API_keys_page import ApiKeysPage
 
 
@@ -45,6 +44,15 @@ class TestApiKey:
         if initial_status == "Active":
             api_keys_page.click_switch_status_icon(row_num)
         api_keys_page.check_is_status_api_key_red(row_num)
+
+    def test_tc_017_02_08_the_active_status_of_api_key_is_black(self, driver):
+        row_num = 1
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        initial_status = api_keys_page.get_api_key_initial_status(row_num)
+        if initial_status == "Inactive":
+            api_keys_page.click_switch_status_icon(row_num)
+        api_keys_page.check_is_status_api_key_black(row_num)
 
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):
         api_keys_page = ApiKeysPage(driver)


### PR DESCRIPTION
TC_017.02.08 : https://trello.com/c/rn0S064C/646-tctc0170203-api-keys-tab-change-status-of-api-key-visibility-clickability-changing-the-color-of-inactive-status-is-red
AT_017.02.08 : https://trello.com/c/DrqzQF6I/647-attc0170208-api-keys-tab-change-status-of-api-key-visibility-clickability-changing-the-color-of-active-status-is-black
