### PR TITLE
test_tc_017_02_06_the_icon_changing_api_key_status_is_clickable is added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -170,3 +170,7 @@ class ApiKeysPage(BasePage):
                 self.click_switch_status_icon(i)
             deactivate_api_key_displayed = self.element_is_displayed(ApiKeysLocator.SWITCH_STATUS_TO_ACTIVE)
             assert deactivate_api_key_displayed, "The icon Deactivate API key does not displayed"
+
+    def check_change_api_key_status_icon_is_clickable(self):
+        change_api_key_status_icon_clickable = self.element_is_clickable(ApiKeysLocator.CHANGE_API_KEY_STATUS_ICON)
+        assert change_api_key_status_icon_clickable, "The icon for changing API key status is not clickable"

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -55,6 +55,11 @@ class TestApiKey:
         api_keys_page.open_api_keys_page()
         api_keys_page.check_is_icon_deactivate_api_key_displayed()
 
+    def test_tc_017_02_06_the_icon_change_api_key_status_is_clickable(self, driver):
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.check_change_api_key_status_icon_is_clickable()
+
     def test_tc_017_02_09_the_icon_activate_api_key_is_displayed(self, driver):
         api_keys_page = ApiKeysPage(driver)
         api_keys_page.open_api_keys_page()


### PR DESCRIPTION
AT_017.02.06 : https://trello.com/c/Bghf9oWe/652-at0170206-api-keys-tab-change-status-of-api-key-visibility-clickability-changingthe-icon-for-change-status-of-api-key-is-clickab
TC_017.02.06 : https://trello.com/c/0ghVVklR/31-tc0170206-api-keys-tab-change-status-of-api-key-visibility-clickability-changingthe-icon-for-change-status-of-api-key-is-clickab