### PR TITLE
test_tc_017_02_11_the_api_key_status_does_not_changed added

### DIFF
--- a/pages/API_keys_page.py
+++ b/pages/API_keys_page.py
@@ -197,3 +197,14 @@ class ApiKeysPage(BasePage):
         assert actual_notice_api_key_statis_changed == expected_notice2 or expected_notice1, "Incorrect text for the" \
                                                                                              " Change API Key status" \
                                                                                              " notice"
+
+    def check_the_api_key_status_does_not_changed(self):
+        initial_status = self.get_api_key_initial_status(1)
+        change_api_key_status_icon = self.element_is_clickable(ApiKeysLocator.CHANGE_API_KEY_STATUS_ICON)
+        change_api_key_status_icon.click()
+        alert = self.driver.switch_to.alert
+        alert.dismiss()
+        actual_api_status = self.get_api_key_initial_status(1)
+        assert actual_api_status == initial_status, "API status was changed after click Cancel button"
+
+

--- a/tests/test_API_keys_page.py
+++ b/tests/test_API_keys_page.py
@@ -85,6 +85,11 @@ class TestApiKey:
         api_keys_page.open_api_keys_page()
         api_keys_page.check_alert_for_confirming_change_api_key_status_is_displayed()
 
+    def test_tc_017_02_11_the_api_key_status_does_not_changed(self, driver):
+        api_keys_page = ApiKeysPage(driver)
+        api_keys_page.open_api_keys_page()
+        api_keys_page.check_the_api_key_status_does_not_changed()
+
 
 
     def test_tc_017_04_01_module_title_create_api_key_is_visible(self, driver):


### PR DESCRIPTION
AT_017.02.11 : https://trello.com/c/LXcAS2U2/657-at0170211-api-keys-tab-change-status-of-api-key-visibility-clickability-changingthe-api-key-status-does-not-change-when-clicking
TC_017.02.11 : https://trello.com/c/YHTSp4wa/654-tc0170211-api-keys-tab-change-status-of-api-key-visibility-clickability-changingthe-api-key-status-does-not-change-when-clicking